### PR TITLE
docs: add a note for Arch Linux that the name of udev rules may needs lexically precede /usr/lib/udev/rules.d/73-seat-late.rules

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -62,6 +62,8 @@ sudo systemctl disable --now webhid-daemon
 # 3. Enable "Daemon as NM host" in the addon settings
 ```
 
+> Note: Rule using the `uaccess` tag needs a name lexically precede `/usr/lib/udev/rules.d/73-seat-late.rules` to be effective on Arch Linux. If your daemon cannot detect hid devices, try renaming `/etc/udev/rules.d/99-webhid.rules` to something like `71-webhid.rules` where the number is less than 73.
+
 **Prefer a persistent root daemon?** Keep the service enabled instead:
 
 ```sh


### PR DESCRIPTION
## What does this PR do?

As talked in issue #3, udev rules using uaccess tag may need priority than 73-seat-late.rules to take effect. This PR add a note in Arch Linux daemon-as-NM-host section, notices user to try renaming their 99-webhid.rules to solve problem.

## Related issue(s)

Closes #3

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance / Benchmark
- [ ] Packaging / CI
- [x] Documentation
- [ ] Tests
- [ ] Other (please describe)

## Testing

Tested with `ATK NK mouse NANO dongle VID:373b PID:1216`

### Rust (daemon, NM host, mock)

- [ ] `cargo build --release` passes, if the change touches Rust code
- [ ] `npm run lint:rs` (cargo clippy) passes with no new warnings
- [ ] `npm run test:rs` passes
- [ ] Tested against a real HID device if the change touches enumeration,
      report descriptor parsing, or the data plane

### Addon (JS)

- [ ] `npm run lint:js` and `npm run lint` (web-ext) pass
- [ ] `npm run test:browser` passes (no hardware needed)
- [ ] `npm run test:e2e` passes if the change touches the data plane or
      worker-spawn paths (see E2E setup note below)
- [ ] `npm run test:benchmark` if the change affects throughput or latency
- [ ] Manually tested the changed area in the browser

E2E needs the debug binaries and one-time Linux setup
(`sudo make install-e2e-udev-rule`); see
[docs/DEVELOPMENT.md](../docs/DEVELOPMENT.md#testing). Running both e2e
projects concurrently requires `--workers=1`.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits style
- [x] I've updated relevant docs (README, DEVELOPMENT.md, ARCHITECTURE.md,
      BENCHMARK.md) if needed
